### PR TITLE
split object model and object config properties into separate files

### DIFF
--- a/config/object_config.yml
+++ b/config/object_config.yml
@@ -25,7 +25,7 @@ properties:
   #         - value 2
   #         - value 3  #      
   #   validations: # Assumes that validations are something extensible, and we want to ship some of them, and have a conversation about what those extensions are # validator: RDF::LiteralValidator # Based on discussion, we are defering decision on whether we need this
-  #      cardinality: 0..n
+  #      obligation: 0..n
   #   facet: #could this and search be simiplified somehow?
   #      faceted: #true/false
   #      facet_group: #facet group name
@@ -48,7 +48,7 @@ properties:
     usage_note: "Preferrably, make the titles of resources unique within a collection. However, there is no hard rule against duplicate object titles."
     sample_value: "Sun God: decorated as Rambird, 1986: front view"
     validations: 
-      cardinality: 1
+      obligation: 1
     facet: 
        faceted: false
     search:
@@ -68,7 +68,7 @@ properties:
   agent_creator: 
     usage_note: "Can be used when lacking specific information on an agent's exact role in creating the resource."
     validations: 
-       cardinality: 0..n
+       obligation: 0..n
     facet:
        faceted: true
        facet_group: creators

--- a/config/object_config.yml
+++ b/config/object_config.yml
@@ -13,12 +13,8 @@ properties:
 
   # Example only:
   # default:
-  #   definition: "This property has not yet been documented."
   #   usage_note: "Multiple instances are allowed, but discouraged. In some contexts it cannot be predicited which value will be displayed."
-  #   predicate: "full.url.for/predicate" # For creator/contributor roles, could this point to an external file where relator roles can be maintained (e.g., https://github.com/chrissyrissmeyer/metadata-ci/blob/master/lib/fields/marcrel.rb)?
   #   sample_value: "The best property ever"
-  #   range:
-  #      uri: "rdfs:Literal"
   #   controlled_values: #use vocabularies or list (not both)
   #      vocabularies: #connection to questioning authority?
   #          uri: http://uri.for.supported/vocabulary
@@ -49,12 +45,8 @@ properties:
   
   
   title: # Property Name
-    definition: "The title of the resource."
     usage_note: "Preferrably, make the titles of resources unique within a collection. However, there is no hard rule against duplicate object titles."
-    predicate: "http://dublincore.org/2012/06/14/dcterms#title"
     sample_value: "Sun God: decorated as Rambird, 1986: front view"
-    range:
-      uri: "rdfs:Literal"      
     validations: 
       cardinality: 1
     facet: 
@@ -74,11 +66,7 @@ properties:
        display_suppressed: false
 
   agent_creator: 
-    definition: "A person or organization responsible for creating the resource."
     usage_note: "Can be used when lacking specific information on an agent's exact role in creating the resource."
-    predicate: "http://dublincore.org/2012/06/14/dcelements#creator"
-    range:
-       uri: "ucsd:Agent"
     validations: 
        cardinality: 0..n
     facet:

--- a/config/object_config.yml
+++ b/config/object_config.yml
@@ -1,7 +1,7 @@
 
 #-------------------
 # Shared Metadata Model
-# Property Settings
+# Object Property Configuration Settings
 #-------------------
 #
 # This section defines every metadata property that can be used

--- a/model/object_properties.yml
+++ b/model/object_properties.yml
@@ -1,7 +1,7 @@
 
 #-------------------
 # Shared Metadata Model
-# Property Settings
+# Object Property Settings
 #-------------------
 #
 # This section defines every metadata property that can be used

--- a/model/object_properties.yml
+++ b/model/object_properties.yml
@@ -17,7 +17,7 @@ properties:
   #   predicate: "full.url.for/predicate" # For creator/contributor roles, could this point to an external file where relator roles can be maintained (e.g., https://github.com/chrissyrissmeyer/metadata-ci/blob/master/lib/fields/marcrel.rb)?
   #   range:
   #      uri: "rdfs:Literal"
-  #   system_obligation: 0..n
+  #   cardinality: 0..n
   
   
   title: # Property Name
@@ -25,13 +25,13 @@ properties:
     predicate: "http://dublincore.org/2012/06/14/dcterms#title"
     range:
       uri: "rdfs:Literal"      
-    system_obligation: 1
+    cardinality: 1
 
   agent_creator: 
     definition: "A person or organization responsible for creating the resource."
     predicate: "http://dublincore.org/2012/06/14/dcelements#creator"
     range:
        uri: "ucsd:Agent"
-    system_obligation: 0..n
+    cardinality: 0..n
 
   

--- a/model/object_properties.yml
+++ b/model/object_properties.yml
@@ -1,0 +1,37 @@
+
+#-------------------
+# Shared Metadata Model
+# Property Settings
+#-------------------
+#
+# This section defines every metadata property that can be used
+# in the system. Individual work types may override some settings
+# defined here. Predicates for each property should be defined
+# here, and cannot be overridden once defined.
+
+properties:
+
+  # Example only:
+  # default:
+  #   definition: "This property has not yet been documented."
+  #   predicate: "full.url.for/predicate" # For creator/contributor roles, could this point to an external file where relator roles can be maintained (e.g., https://github.com/chrissyrissmeyer/metadata-ci/blob/master/lib/fields/marcrel.rb)?
+  #   range:
+  #      uri: "rdfs:Literal"
+  #   system_obligation: 0..n
+  
+  
+  title: # Property Name
+    definition: "The title of the resource."
+    predicate: "http://dublincore.org/2012/06/14/dcterms#title"
+    range:
+      uri: "rdfs:Literal"      
+    system_obligation: 1
+
+  agent_creator: 
+    definition: "A person or organization responsible for creating the resource."
+    predicate: "http://dublincore.org/2012/06/14/dcelements#creator"
+    range:
+       uri: "ucsd:Agent"
+    system_obligation: 0..n
+
+  


### PR DESCRIPTION
Split content in original shared_schema.yml file into two files  object_properties.yml (including property name, definition, predicate, range and system obligation) and  object_config.yml including all of the other settings.

