### PR TITLE
JSON Schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+gem 'json_schemer'
+gem 'yamllint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  specs:
+    ecma-re-validator (0.2.0)
+      regexp_parser (~> 1.2)
+    hana (1.3.5)
+    json_schemer (0.2.0)
+      ecma-re-validator (~> 0.2.0)
+      hana (~> 1.3.3)
+      regexp_parser (~> 1.2.0)
+      uri_template (~> 0.7.0)
+    regexp_parser (1.2.0)
+    trollop (2.9.9)
+    uri_template (0.7.0)
+    yamllint (0.0.9)
+      trollop (~> 2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json_schemer
+  yamllint
+
+BUNDLED WITH
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ m3.yml
   122:4     warning  comment not indented like content  (comments-indentation)
   124:6     warning  comment not indented like content  (comments-indentation)
 ```
+
+# Tools
+
+* yamllint (`gem install yamllint`) - comannd line YAML validation
+* [jsonschemalint](https://jsonschemalint.com/#/version/draft-07/markup/json) - web-based tool for validating json against a JSON schema
+* [YAML Converter](https://codebeautify.org/yaml-to-json-xml-csv) - web-based tool for converting YAML to JSON
+* `validate.rb` - lightweight script to validate an m3 YAML specification against the JSON Schema (`m3_json_schema.json`); run with ruby validate.rb m3.yml

--- a/m3.yml
+++ b/m3.yml
@@ -1,4 +1,3 @@
----
 #-------------------
 # M3 Metadata Model
 #-------------------
@@ -18,7 +17,7 @@
 profile:
   responsibility: https://wiki.duraspace.org/display/samvera/Samvera+Metadata+Interest+Group
   responsibility_statement: Samvera Metadata Interest Group
-  date_modified: 2019-07-03
+  date_modified: "2019-07-03"
   type: metadata models
   version: 0.8
 
@@ -66,13 +65,13 @@ classes:
 # properties:
 #   property_name:  Stable generic local name for the property.
 #     display_label:  Human-readable label for the property.  Context specific display_labels provided as a list using the class and value.
-#        - default: Default display label.
+#        default: Default display label.
 #        - MyCustomWorkType: Context dependent display label.
 #     definition:  The definition for the metadata property being described.
-#        - default: Default definition.
+#        default: Default definition.
 #        - MyCustomWorkType: Context dependent definition.
 #     usage_guidelines:  Description of how the defined property should be used (helper text, hints, deposit text, etc.)
-#        - default: Default usage guidelines.
+#        default: Default usage guidelines.
 #        - MyCustomWorkType: Context dependent usage guidelines.
 #     requirement:  Whether the property is required, optional, recommended, etc. from a best practices standpoint.
 #     controlled_values:
@@ -103,17 +102,18 @@ classes:
 properties:
   creator:
     display_label:
-      - default: "Creator(s)"
+      default: "Creator(s)"
     definition:
-      - default: "A person or organization responsible for creating the resource."
+      default: "A person or organization responsible for creating the resource."
     usage_guidelines:
-      - default: "Record in lastname, firstname order."
+      default: "Record in lastname, firstname order."
     requirement: "recommended, if applicable"
     # controlled_value:
     #   format: http://www.w3.org/2001/XMLSchema#anyURI
     #   sources:
     #     - "/qa/terms/local/roles/"
-    sample_value: Smith, John
+    sample_value: 
+      - Smith, John
     property_uri: http://purl.org/dc/elements/1.1/creator
     available_on:
       class:
@@ -130,13 +130,14 @@ properties:
 
   date_created:
     display_label:
-      - default: "Date Created"
+      default: "Date Created"
     definition:
-      - default: "The date on which the work was created."
+      default: "The date on which the work was created."
     usage_guidelines:
-      - default: "Enter in yyyy-mm-dd format."
+      default: "Enter in yyyy-mm-dd format."
     requirement: recommended
-    sample_value: "2019-04-11"
+    sample_value: 
+      - "2019-04-11"
     property_uri: http://purl.org/dc/terms/created
     available_on:
       class:
@@ -147,21 +148,21 @@ properties:
     syntax: edtf
     cardinality:
       minimum: 0
-      maximum:
     index_documentation: "Date created should be indexed as a searchable, displayable, and facetable field."
     validations:
       match_regex: "[\\d]{4}"
     mapping:
-    dpla: "http://purl.org/dc/elements/1.1/date"
+      dpla: "http://purl.org/dc/elements/1.1/date"
 
   title:
     display_label:
-      - default: "Title"
+      default: "Title"
     definition:
-      - default: "A name to aid in identifying a work or collection."
-      - collection: "A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository."
+      default: "A name to aid in identifying a work or collection."
+      collection: "A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository."
     requirement: required
-    sample_value: "On the Road"
+    sample_value: 
+      - "On the Road"
     property_uri: http://purl.org/dc/terms/title
     available_on:
       class:

--- a/m3_json_schema.json
+++ b/m3_json_schema.json
@@ -1,0 +1,390 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/m3_json_schema.json",
+  "type": "object",
+  "title": "The M3 JSON Schema",
+  "comment": "profile, classes and properties are required; mappings is not",
+  "required": [
+    "profile",
+    "classes",
+    "properties"
+  ],
+  "properties": {
+    "profile": {
+      "$id": "#/properties/profile",
+      "type": "object",
+      "title": "Profile Information",
+      "description": "Administrative information about the profile or model defined in the file.",
+      "additionalProperties": false,
+      "required": [
+        "responsibility",
+        "date_modified"
+      ],
+      "properties": {
+        "responsibility": {
+          "$id": "#/properties/profile/responsibility",
+          "title": "Responsiblity",
+          "description": "uri for the organization or individual responsible for maintaining the profile",
+          "type": "string",
+          "format": "uri",
+          "examples": [
+            "https://wiki.duraspace.org/display/samvera/Samvera+Metadata+Interest+Group"
+          ]
+        },
+        "responsibility_statement": {
+          "$id": "#/properties/profile/responsibility_statement",
+          "title": "Reponsibility Statement",
+          "description": "statement of the organization or individual responsible for maintaining the profile",
+          "type": "string",
+          "examples": [
+            "Samvera Metadata Interest Group"
+          ]
+        },
+        "date_modified": {
+          "$id": "#/properties/profile/date_modified",
+          "title": "Date Modified",
+          "description": "the date the profile was last altered",
+          "type": "string",
+          "format": "date",
+          "comment": "In YAML, dates must be wrapped in quotes to be validated by json schema",
+          "examples": [
+            "2019-07-03"
+          ]
+        },
+        "type": {
+          "$id": "#/properties/profile/type",
+          "title": "Type",
+          "description": "type of thing does the profile describe",
+          "type": "string",
+          "examples": [
+            "metadata models"
+          ]
+        },
+        "version": {
+          "$id": "#/properties/profile/version",
+          "title": "Version",
+          "description": "version of the profile",
+          "type": "number",
+          "examples": [
+            0.8
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "$id": "#/properties/mappings",
+      "type": "object",
+      "title": "Mapping Definitions",
+      "description": "Definition of the mappings to different services or target schemas referenced in the profile.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[a-z_]*$"
+      },
+      "examples": [
+        {
+          "dpla": {
+            "name": "Digital Public Library of America"
+          }
+        },
+        {
+          "datacite": {
+            "name": "DataCite"
+          }
+        },
+        {
+          "dc": {
+            "name": "Dublin Core"
+          }
+        }
+      ]
+    },
+    "classes": {
+      "$id": "#/properties/classes",
+      "type": "object",
+      "title": "Class Definitions",
+      "description": "Definition of the classes used in the profile. Classes should be provided with a generic local name for the class, in CamelCase.",
+      "comment": "Class names are pattern matched.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["display_label"],
+        "properties": {
+          "schema_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URI for the class, from a local or shared ontology."
+          },
+          "display_label": {
+            "type": "string",
+            "description": "Human-readable label for the class.",
+            "comment": "For classes, display label is a string.",
+            "examples": [
+              "Generic Work"
+            ]
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[a-zA-Z]*$"
+      },
+      "examples": [
+        {
+          "GenericWork": {
+            "display_label": "Generic Work"
+          }
+        },
+        {
+          "Collection": {
+            "display_label": "Collection"
+          }
+        },
+        {
+          "Agent": {
+            "display_label": "Agent",
+            "schema_uri": "http://id.loc.gov/ontologies/bibframe/Agent"
+          }
+        }
+      ]
+    },
+    "properties": {
+      "$id": "#/properties/properties",
+      "type": "object",
+      "title": "Property Definitions",
+      "description": "Definition of the properties used in the model. Properties should be provided with a stable generic local name for the property. Names must be lower case alpha characters separated with underscores.",
+      "comment": "Property names pattern matched.",
+      "propertyNames": {
+        "pattern": "^[a-z_]*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["display_label"],  
+        "properties": {
+
+          "display_label": {
+            "type": "object",
+            "description": "Human-readable label for the property.  Context specific display_labels provided as a list using the class and value.",
+            "properties": {
+              "default": {
+                "type": "string",
+                "description": "Default value."
+              }
+            },
+            "examples": [
+              {
+                "default": "Default display label.",
+                "MyCustomWorkType": "Context dependent display label."
+              }
+            ]
+          },
+          "definition": {
+            "type": "object",
+            "description": "The definition for the metadata property being described.",
+            "properties": {
+              "default": {
+                "type": "string",
+                "description": "Default value."
+              }
+            },
+            "examples": [
+              {
+                "default": "Default display label.",
+                "MyCustomWorkType": "Context dependent display label."
+              }
+            ]
+          },
+          "usage_guidelines": {
+            "type": "object",
+            "description": "Description of how the defined property should be used (helper text, hints, deposit text, etc.)",
+            "properties": {
+              "default": {
+                "type": "string",
+                "description": "Default value."
+              }
+            },
+            "examples": [
+              {
+                "default": "Default display label.",
+                "MyCustomWorkType": "Context dependent display label."
+              }
+            ]
+          },
+          "requirement": {
+            "type": "string",
+            "description": "Whether the property is required, optional, recommended, etc. from a best practices standpoint.",
+            "examples": [
+              "recommended, if applicable"
+            ]
+          },
+          "controlled_value": {
+            "type": "object",
+            "description": "",
+            "properties": {
+              "format": {
+                "type": "string",
+                "description": "Controlled vocabulary constraint on the property's value.",
+                "examples": []
+              },
+              "sources": {
+                "type": "array",
+                "description": "Link to a controlled vocabulary source list or file path to a config file listing accepted values.",
+                "items": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "examples": []
+              }
+            },
+            "examples": [
+              {
+                "controlled_value": {
+                  "format": "http://www.w3.org/2001/XMLSchema#anyURI",
+                  "sources": [
+                    "/qa/terms/local/roles/"
+                  ]
+                }
+              }
+            ]
+          },
+          "sample_value": {
+            "type": "array",
+            "description": "Example value(s) for the property.",
+            "examples": [
+              [
+                "Smith, John",
+                "Library of Congress"
+              ]
+            ]
+          },
+          "property_uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "URI for the property, from a local or shared ontology.",
+            "examples": [
+              "http://purl.org/dc/elements/1.1/creator"
+            ]
+          },
+          "available_on": {
+            "type": "object",
+            "description": "The objects and/or work types is this property available on (defined in 'class definitions' section.)",
+            "properties": {
+              "class": {
+                "type": "array"
+              }
+            },
+            "examples": [
+              {
+                "class": [
+                  "Collection",
+                  "MyCustomWorkType"
+                ]
+              }
+            ]
+          },
+          "range": {
+            "type": "string",
+            "format": "uri",
+            "description": "Class constraint on the property's value.  If there is no value provided, the assumed default range is http://www.w3.org/2000/01/rdf-schema#Literal",
+            "default": "http://www.w3.org/2000/01/rdf-schema#Literal",
+            "examples": [
+              "http://www.w3.org/2000/01/rdf-schema#Literal"
+            ]
+          },
+          "data_type": {
+            "type": "string",
+            "format": "uri",
+            "description": "Type constraint on the property's value. If there is no value provided, the assumed default data_type is http://www.w3.org/2001/XMLSchema#string. If multiple data types are possible, general best practice is to use the most specific type that applies to all values.  If multiple types are listed, the lowest common denominator will be used for validation.",
+            "default": "http://www.w3.org/2001/XMLSchema#string",
+            "examples": [
+              "http://www.w3.org/2001/XMLSchema#string"
+            ]
+          },
+          "syntax": {
+            "type": "string",
+            "description": "Type constraint on the property's value. If there is no value provided, the assumed default data_type is http://www.w3.org/2001/XMLSchema#string. If multiple data types are possible, general best practice is to use the most specific type that applies to all values.  If multiple types are listed, the lowest common denominator will be used for validation.",
+            "examples": [
+              "edtf"
+            ]
+          },
+          "cardinality": {
+            "type": "object",
+            "description": "System cardinality and obligation.",
+            "properties": {
+              "minimum": {
+                "type": "integer",
+                "description": "Minimum number of values the property must have.  If there is no value provided, the assumed default minimum is 0.",
+                "default": 0,
+                "examples": [
+                  1
+                ]
+              },
+              "maximum": {
+                "type": "integer",
+                "description": "Maximum number of values the property may have.  If there is no value provided, the assumed default maximum is unlimited.",
+                "examples": [
+                  5
+                ]
+              }
+            },
+            "examples": [
+              {
+                "cardinality": {
+                  "minimum": 0,
+                  "maximum": 100
+                }
+              }
+            ]
+          },
+          "index_documentation": {
+            "type": "string",
+            "description": "Free text documentation field about whether a property should be faceted, searchable, displayable, treated as text, etc.",
+            "examples": [
+              "searchable, displayable, creator facet"
+            ]
+          },
+          "validations": {
+            "type": "object",
+            "description": "Regular Expression pattern each value must match to be valid.",
+            "properties": {
+              "match_regex": {
+                "type": "string",
+                "description": "Regular Expression pattern each value must match to be valid.",
+                "examples": [
+                  "^[a-z_]*$"
+                ]
+              }
+            },
+            "examples": [
+              {
+                "validations": {
+                  "match_regex": "^[a-z_]*$"
+                }
+              }
+            ]
+          },
+          "mapping": {
+            "type": "object",
+            "description": "A pair value defining the target property for a mapping (defined in 'mapping definitions' section.)",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_]*$"
+            },
+            "examples": [
+              {
+                "dpla": "http://purl.org/dc/elements/1.1/creator"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/validate.rb
+++ b/validate.rb
@@ -44,5 +44,5 @@ end
 if valid?
   exit(true)
 else
-  exit(0)
+  exit(1)
 end

--- a/validate.rb
+++ b/validate.rb
@@ -1,0 +1,36 @@
+require "json_schemer"
+require 'pathname'
+
+@schema = Pathname.new('m3_json_schema.json')
+
+puts "can't fine the file" unless File.exist?(ARGV[0])
+exit unless File.exist?(ARGV[0])
+
+@specification = YAML.load_file(ARGV[0])
+
+def load_schema
+  begin
+    @schemer = JSONSchemer.schema(@schema)
+    puts "Schema valid? true"
+    true
+  rescue => e
+    puts e.message
+    puts "Schema valid? false"
+  end
+end
+
+def validate!
+  puts "Specification valid? #{@schemer.valid?(@specification)}"
+  @schemer.validate(@specification)
+end
+
+result = validate! if load_schema == true
+
+result.to_a.each do | error |
+  puts "Data: #{error['data']}"
+  puts "Data pointer: #{error['data_pointer']}"
+  puts "Schema: #{error['schema']}"
+  puts "Schema pointer: #{error['schema_pointer']}"
+  puts "Type: #{error['type']}"
+  puts "\n"
+end unless result.nil?

--- a/validate.rb
+++ b/validate.rb
@@ -1,4 +1,6 @@
-require "json_schemer"
+# frozen_string_literal: true
+
+require 'json_schemer'
 require 'pathname'
 
 @schema = Pathname.new('m3_json_schema.json')
@@ -9,28 +11,38 @@ exit unless File.exist?(ARGV[0])
 @specification = YAML.load_file(ARGV[0])
 
 def load_schema
-  begin
-    @schemer = JSONSchemer.schema(@schema)
-    puts "Schema valid? true"
-    true
-  rescue => e
-    puts e.message
-    puts "Schema valid? false"
-  end
+  @schemer = JSONSchemer.schema(@schema)
+  puts 'Schema valid? true'
+  true
+rescue StandardError => e
+  puts e.message
+  puts 'Schema valid? false'
 end
 
 def validate!
-  puts "Specification valid? #{@schemer.valid?(@specification)}"
   @schemer.validate(@specification)
 end
 
-result = validate! if load_schema == true
+def valid?
+  valid = @schemer.valid?(@specification)
+  puts "Specification valid? #{valid}"
+  valid
+end
 
-result.to_a.each do | error |
-  puts "Data: #{error['data']}"
-  puts "Data pointer: #{error['data_pointer']}"
-  puts "Schema: #{error['schema']}"
-  puts "Schema pointer: #{error['schema_pointer']}"
-  puts "Type: #{error['type']}"
-  puts "\n"
-end unless result.nil?
+if load_schema
+  result = validate!
+  result&.to_a&.each do |error|
+    puts "Data: #{error['data']}"
+    puts "Data pointer: #{error['data_pointer']}"
+    puts "Schema: #{error['schema']}"
+    puts "Schema pointer: #{error['schema_pointer']}"
+    puts "Type: #{error['type']}"
+    puts "\n"
+  end
+end
+
+if valid?
+  exit(true)
+else
+  exit(0)
+end


### PR DESCRIPTION
This PR adds a JSON Schema for the m3 specification (`m3_json_schema.json`). This can be used to validate files against the specification.

In addition:

* makes a couple of changes to the m3.yml file
* adds a rough validation script
* adds some tools info to the readme

The examples currently fail - if folks are happy with this approach I can validate and update those. 