### PR TITLE
Date Created syntax

### DIFF
--- a/m3.yml
+++ b/m3.yml
@@ -151,7 +151,7 @@ properties:
     definition:
       default: "The date on which the work was created."
     usage_guidelines:
-      default: "Enter in yyyy-mm-dd format."
+      default: “Enter in YYYY-MM-DD, YYYY-MM, or YYYY format.”
     requirement: recommended
     sample_value: 
       - "2019-04-11"
@@ -161,7 +161,7 @@ properties:
         - genericWork
     range: http://www.w3.org/2000/01/rdf-schema#Literal
     data_type: http://www.w3.org/2001/XMLSchema#date
-    syntax: edtf
+    syntax: W3CDTF
     cardinality:
       minimum: 0
     index_documentation: "Date created should be indexed as a searchable, displayable, and facetable field."


### PR DESCRIPTION
Date Created syntax should ideally be W3CDTF (https://www.w3.org/TR/NOTE-datetime) rather than EDTF (https://www.loc.gov/standards/datetime/). EDTF is very flexible and includes YYYY, YYYY-MM, and YYYY-MM-DD in level 0. However, the other levels could create problems for searching if it's not necessary - particularly for institutional repositories taking scholarly works. EDTF is useful for digitized special collections and archival materials but requires other scripting to convert it into something more readable (https://github.com/duke-libraries/edtf-humanize). Also, Usage Guidelines for Date Created should allow for other W3CDTF options.